### PR TITLE
[SubMob/ParserMob#261] Point project automation at merged reusable workflow

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -14,8 +14,8 @@ on:
 
 jobs:
   ProjectAutomations:
-    uses: Oztechan/Global/.github/workflows/reusable-project-submodules.yml@8610938e630b3ed86127765237fe3647b9fabd4f
+    uses: Oztechan/Global/.github/workflows/reusable-project.yml@d2d760603ad21c392c22ab10508941b6f65a3cf1
     with:
       project_id: 1
-    secrets:
+      organization: SubMob    secrets:
       PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -17,5 +17,6 @@ jobs:
     uses: Oztechan/Global/.github/workflows/reusable-project.yml@d2d760603ad21c392c22ab10508941b6f65a3cf1
     with:
       project_id: 1
-      organization: SubMob    secrets:
+      organization: SubMob
+    secrets:
       PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   ProjectAutomations:
-    uses: Oztechan/Global/.github/workflows/reusable-project.yml@d5593d5af7576d25ef10aa804c2bf52efe5cf53c
+    uses: Oztechan/Global/.github/workflows/reusable-project.yml@6c7b329cd65b22c4cbdf59dda5f9436e54f1c26f
     with:
       project_id: 1
       organization: SubMob

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   ProjectAutomations:
-    uses: Oztechan/Global/.github/workflows/reusable-project.yml@d2d760603ad21c392c22ab10508941b6f65a3cf1
+    uses: Oztechan/Global/.github/workflows/reusable-project.yml@d5593d5af7576d25ef10aa804c2bf52efe5cf53c
     with:
       project_id: 1
       organization: SubMob


### PR DESCRIPTION
Closes #261

Switches from the removed reusable-project-submodules.yml to the merged reusable-project.yml pinned at `d2d760603ad21c392c22ab10508941b6f65a3cf1` (Oztechan/Global#225), adding `organization: SubMob`. On PR open the linked issue now moves to / stays in `🚧 In Progress`; only the PR moves to `🏗 PR Review`. project_id (1) and secrets are unchanged.